### PR TITLE
ボタンのシャドーバグ修正

### DIFF
--- a/TeePod/Components/PowerButton.swift
+++ b/TeePod/Components/PowerButton.swift
@@ -26,9 +26,8 @@ struct PowerButton: View {
                 Circle()
                     .fill(main_color)
                     .frame(width:90,height:90)
-                    .shadow(color: shadow_light, radius: 10, x: 10, y: 10)
-                    .shadow(color: shadow_dark, radius: 10, x: -5, y: -5)
-                    
+                    .shadow(color: shadow_dark, radius: 10, x: 10, y: 10)
+                    .shadow(color: shadow_light, radius: 10, x: -5, y: -5)
                     
                     .overlay(Circle()
                         .fill(LinearGradient(


### PR DESCRIPTION
## 🍦概要
- 電源ボタンのスタイルのバグを修正

## 🛠やったこと
- 左上と左下のシャドーの色が逆になってたので正しいものに修正したよ

## ⚠️注意点
- 
