### PR TITLE
疲れ度を結果ページに表示

### DIFF
--- a/TeePod/modules/Check/CheckPresenter.swift
+++ b/TeePod/modules/Check/CheckPresenter.swift
@@ -83,8 +83,8 @@ extension CheckPresenter {
 }
 
 extension CheckPresenter {
-    func resultLink<Content: View>(tiredness: Float, @ViewBuilder content: () -> Content) -> some View {
-        return NavigationLink(destination: router.makeResultView(tiredness: tiredness)) {
+    func resultLink<Content: View>(tiredness: Float, isActive: Binding<Bool>, @ViewBuilder content: () -> Content) -> some View {
+        return NavigationLink(destination: router.makeResultView(tiredness: tiredness), isActive: isActive) {
             content()
         }
     }

--- a/TeePod/modules/Check/CheckPresenter.swift
+++ b/TeePod/modules/Check/CheckPresenter.swift
@@ -83,8 +83,8 @@ extension CheckPresenter {
 }
 
 extension CheckPresenter {
-    func resultLink<Content: View>(@ViewBuilder content: () -> Content) -> some View {
-        return NavigationLink(destination: router.makeResultView()) {
+    func resultLink<Content: View>(tiredness: Float, @ViewBuilder content: () -> Content) -> some View {
+        return NavigationLink(destination: router.makeResultView(tiredness: tiredness)) {
             content()
         }
     }

--- a/TeePod/modules/Check/CheckRouter.swift
+++ b/TeePod/modules/Check/CheckRouter.swift
@@ -20,7 +20,7 @@ final class CheckRouter {
 }
 
 extension CheckRouter {
-    func makeResultView() -> ResultView {
-        return ResultRouter().build()
+    func makeResultView(tiredness: Float) -> ResultView {
+        return ResultRouter().build(tiredness: tiredness)
     }
 }

--- a/TeePod/modules/Check/CheckView.swift
+++ b/TeePod/modules/Check/CheckView.swift
@@ -49,6 +49,7 @@ struct CheckView: View {
                 Spacer()
                 Text("疲れ度が低ければカウントダウンを延長します")
                     .foregroundColor(font_color)
+                Spacer()
                 
                 if self.presenter.faceAttributes != nil {
                     self.presenter.resultLink(tiredness: 100 - self.presenter.faceAttributes!.smile * 100, isActive: $isPushed) {

--- a/TeePod/modules/Check/CheckView.swift
+++ b/TeePod/modules/Check/CheckView.swift
@@ -15,6 +15,7 @@ let shadow_dark = Color(UIColor.MyThema.shadow_dark)
 
 struct CheckView: View {
     @ObservedObject var presenter: CheckPresenter
+    @State private var isPushed = true
     
     var body: some View {
         ZStack {
@@ -49,16 +50,11 @@ struct CheckView: View {
                 Text("疲れ度が低ければカウントダウンを延長します")
                     .foregroundColor(font_color)
                 
-                Spacer()
-                
                 if self.presenter.faceAttributes != nil {
-                    self.presenter.resultLink(tiredness: 100 - self.presenter.faceAttributes!.smile * 100) {
-                        Text("診断結果")
-                            .foregroundColor(font_color)
+                    self.presenter.resultLink(tiredness: 100 - self.presenter.faceAttributes!.smile * 100, isActive: $isPushed) {
+                        EmptyView()
                     }
                 }
-                
-                Spacer()
             }
             .navigationBarTitle(Text("診断中"), displayMode: .inline)
         }

--- a/TeePod/modules/Check/CheckView.swift
+++ b/TeePod/modules/Check/CheckView.swift
@@ -51,14 +51,11 @@ struct CheckView: View {
                 
                 Spacer()
                 
-//                self.presenter.resultLink {
-//                    Text("診断結果")
-//                        .foregroundColor(font_color)
-//                }
-                
                 if self.presenter.faceAttributes != nil {
-                    Text("疲れ度：" + String(100 - self.presenter.faceAttributes!.smile * 100))
-                        .foregroundColor(font_color)
+                    self.presenter.resultLink(tiredness: 100 - self.presenter.faceAttributes!.smile * 100) {
+                        Text("診断結果")
+                            .foregroundColor(font_color)
+                    }
                 }
                 
                 Spacer()

--- a/TeePod/modules/Result/ResultPresenter.swift
+++ b/TeePod/modules/Result/ResultPresenter.swift
@@ -15,6 +15,22 @@ final class ResultPresenter: ObservableObject {
     private let interactor = ResultInteractor()
     
     let objectWillChange = ObservableObjectPublisher()
+    
+    @Published var tiredness: Float = 0 {
+        willSet {
+            self.objectWillChange.send()
+        }
+    }
+    
+    func updateTiredness(tiredness: Float) {
+        DispatchQueue.main.async {
+            self.tiredness = tiredness
+        }
+    }
+    
+    init(tiredness: Float) {
+        updateTiredness(tiredness: tiredness)
+    }
 }
 
 extension ResultPresenter {}

--- a/TeePod/modules/Result/ResultRouter.swift
+++ b/TeePod/modules/Result/ResultRouter.swift
@@ -11,8 +11,8 @@ import SwiftUI
 import UIKit
 
 final class ResultRouter {
-    func build() -> ResultView {
-        let presenter = ResultPresenter()
+    func build(tiredness: Float) -> ResultView {
+        let presenter = ResultPresenter(tiredness: tiredness)
         let view = ResultView(presenter: presenter)
         
         return view

--- a/TeePod/modules/Result/ResultView.swift
+++ b/TeePod/modules/Result/ResultView.swift
@@ -17,7 +17,6 @@ struct ResultView: View {
     let shadow_dark = Color(UIColor.MyThema.shadow_dark)
     let gradient_start = UnitPoint(x: 0, y: 0)
     let gradient_end = UnitPoint(x: 1, y: 1)
-    var result_score = 100
     var result_min = 30
     var result_message = "カウントダウンが延長されました"
     
@@ -46,7 +45,7 @@ struct ResultView: View {
                         Text("疲れ度")
                         Spacer().frame(height: 10)
                         HStack(alignment: .bottom) {
-                            Text(String(result_score))
+                            Text(String(Int(self.presenter.tiredness)))
                                 .font(.system(size: 50, weight: .bold, design: .default))
                             Text("/100")
                                 .font(.title)
@@ -80,7 +79,7 @@ struct ResultView: View {
 
 struct ResultView_Previews: PreviewProvider {
     static var previews: some View {
-        let presenter = ResultPresenter()
+        let presenter = ResultPresenter(tiredness: 100.0)
         return Group {
             ResultView(presenter: presenter).previewDevice(PreviewDevice(rawValue: "iPhone 7 Plus"))
             ResultView(presenter: presenter).previewDevice(PreviewDevice(rawValue: "iPhone 7"))


### PR DESCRIPTION
## 🍦概要
- 疲れ度を結果ページに表示できるようにしたよ
- 疲れ度を算出したら自動的に結果ページに遷移されるようにしたよ
close: #31 
close: #30

## 🛠やったこと
- チェックページで算出した疲れ度を結果ページをビルドする時に値を受け渡すように修正したよ

## ⚠️注意点
- 
